### PR TITLE
Fix YDLidar driver reference in limo_start.launch and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,27 @@ This repository contains ROS packages for limo.
 * limo_description: URDF model for limo 
 
 ## Build from source code
-Clone the repository and catkin_make:
-```
-    $ cd ~/catkin_ws/src
-    $ git clone https://github.com/agilexrobotics/limo_ros.git
-    $ cd ..
-    $ catkin_make
-```
+
+1. **Install YDLidar-SDK (Required Dependency)**  
+   `ydlidar_ros_driver` depends on the YDLidar-SDK library.
+
+   - **If you haven’t installed it or have an outdated version**:
+     ```bash
+     git clone https://github.com/YDLIDAR/YDLidar-SDK.git
+     cd YDLidar-SDK
+     # Follow the build instructions in the SDK's README.md:
+     # https://github.com/YDLIDAR/YDLidar-SDK/blob/master/doc/howto/how_to_build_and_install.md
+     ```
+
+   - **If you already have the latest SDK installed**, skip to the next step.
+
+2. **Clone and build `limo_ros` and `ydlidar_ros_driver`**:
+   ```bash
+   cd ~/catkin_ws/src
+   git clone https://github.com/YDLIDAR/ydlidar_ros_driver.git
+   git clone https://github.com/agilerobotics/limo_ros.git
+   cd ~/catkin_ws
+   catkin_make
 
 
 ## Usage

--- a/limo_bringup/launch/limo_start.launch
+++ b/limo_bringup/launch/limo_start.launch
@@ -10,7 +10,7 @@
         <arg name="use_mcnamu" default="$(arg use_mcnamu)" />
     </include>
 
-    <include file="$(find ydlidar_ros)/launch/X2L.launch" />
+    <include file="$(find ydlidar_ros_driver)/launch/X2.launch" />
 
     <node pkg="tf" type="static_transform_publisher" name="base_link_to_laser_link" args="0.105 0.0 0.08 0.0 0.0 0.0 /base_link /laser_link 10" />
     <node pkg="tf" type="static_transform_publisher" name="base_link_to_imu_link" args="0.0 0.0 0.0 0.0 0.0 0.0 /base_link /imu_link 10" />


### PR DESCRIPTION
### Changes  
- Updated `limo_start.launch` to use `ydlidar_ros_driver/X2.launch` instead of the deprecated `ydlidar_ros/X2L.launch`.  
- Added explicit installation steps for **YDLidar-SDK** and `ydlidar_ros_driver` in the README.  


Due to missing dependencies, users previously faced build errors when trying to launch:
```bash
roslaunch limo_bringup limo_start.launch
```
the updated README resolves this.  